### PR TITLE
Add start/stop functionality

### DIFF
--- a/include/Machine.h
+++ b/include/Machine.h
@@ -10,6 +10,10 @@ class Machine {
 public:
     explicit Machine(const std::string& id);
 
+    void start();
+    void stop();
+    bool isRunning() const;
+
     void setSensorValue(const std::string& type, double value);
     std::optional<double> getSensorValue(const std::string& type) const;
     std::unordered_map<std::string, double> getAllSensorValues() const;
@@ -25,6 +29,8 @@ public:
 private:
     std::string id;
     std::unordered_map<std::string, double> sensors;
+
+    bool running = true;
 
     bool overheating = false;
     bool tooCold = false;

--- a/include/MachineController.h
+++ b/include/MachineController.h
@@ -27,6 +27,7 @@ private:
 
     void handleTemperature(const std::string& payload);
     void handleVibration(const std::string& payload);
+    void handleState(const std::string& payload);
 };
 
 #endif // MACHINECONTROLLER_H

--- a/src/Machine.cpp
+++ b/src/Machine.cpp
@@ -2,7 +2,22 @@
 
 Machine::Machine(const std::string& id) : id(id) {}
 
+void Machine::start() {
+    running = true;
+}
+
+void Machine::stop() {
+    running = false;
+}
+
+bool Machine::isRunning() const {
+    auto val = getSensorValue("state");
+    return val.has_value() && val.value() > 0.5;
+}
+
 void Machine::setSensorValue(const std::string& type, double value) {
+
+    if (!running) return;
     sensors[type] = value;
 
     if (type == "temp") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,24 @@ target_include_directories(vibration_sensor_tests PRIVATE ${PROJECT_SOURCE_DIR}/
 target_link_libraries(vibration_sensor_tests PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 add_test(NAME VibrationSensorTests COMMAND vibration_sensor_tests)
 
+# MachineController state handling test
+add_executable(machine_state_tests
+        ${PROJECT_SOURCE_DIR}/tests/MachineStateTest.cpp
+        ${PROJECT_SOURCE_DIR}/src/MachineController.cpp
+        ${PROJECT_SOURCE_DIR}/src/Machine.cpp
+)
+
+target_include_directories(machine_state_tests PRIVATE ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(machine_state_tests PRIVATE
+        Catch2::Catch2WithMain
+        nlohmann_json::nlohmann_json
+)
+
+add_test(NAME MachineStateTests COMMAND machine_state_tests)
+
+
 # Optional meta target to build all test binaries
 add_custom_target(all_tests
-        DEPENDS machine_controller_tests temperature_sensor_tests factory_controller_tests machine_tests vibration_sensor_tests
+        DEPENDS machine_controller_tests temperature_sensor_tests factory_controller_tests machine_tests vibration_sensor_tests machine_state_tests
 )

--- a/tests/FactoryControllerTest.cpp
+++ b/tests/FactoryControllerTest.cpp
@@ -8,14 +8,17 @@ using Catch::Approx;
 using Catch::Matchers::WithinAbs;
 
 TEST_CASE("FactoryController handles new machine messages") {
-    FactoryController fc;
+    FactoryController factory;
+
+    // Start machine
+    factory.handleMessage("factory/machineX/state", R"({"state": "start"})");
 
     std::string topic = "factory/machineX/temp";
     std::string payload = R"({"temp": 42.0})";
 
-    fc.handleMessage(topic, payload);
+    factory.handleMessage(topic, payload);
 
-    auto mc = fc.getMachine("machineX");
+    auto mc = factory.getMachine("machineX");
     REQUIRE(mc != nullptr);
 
     auto machine = mc->getMachine();
@@ -47,11 +50,18 @@ TEST_CASE("FactoryController handles malformed topics gracefully") {
 
 TEST_CASE("FactoryController returns correct snapshot of sensor states", "[FactoryController][Snapshot]") {
     FactoryController factory;
+    factory.handleMessage("factory/machine0/state", R"({"state": "start"})");
+    factory.handleMessage("factory/machine1/state", R"({"state": "start"})");
+    factory.handleMessage("factory/machine2/state", R"({"state": "start"})");
 
     // Simulate messages from machines
     factory.handleMessage("factory/machine0/temp", R"({"temp": 12.5})");
     factory.handleMessage("factory/machine1/temp", R"({"temp": 78.0})");
     factory.handleMessage("factory/machine2/temp", R"({"temp": 91.3})");
+
+    factory.handleMessage("factory/machine0/state", R"({"state": "start"})");
+    factory.handleMessage("factory/machine1/state", R"({"state": "start"})");
+    factory.handleMessage("factory/machine2/state", R"({"state": "start"})");
 
     auto snapshot = factory.getSensorStates();
 

--- a/tests/MachineStateTest.cpp
+++ b/tests/MachineStateTest.cpp
@@ -1,0 +1,36 @@
+﻿#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "MachineController.h"
+
+using Catch::Matchers::Equals;
+
+TEST_CASE("MachineController handles machine state changes", "[MachineController][State]") {
+    MachineController mc("machineTest");
+
+    SECTION("Initial state is stopped") {
+        REQUIRE_FALSE(mc.getMachine()->isRunning());
+    }
+
+    SECTION("Handles start state") {
+        mc.handleSensor("state", R"({"state":"start"})");
+        REQUIRE(mc.getMachine()->isRunning());
+    }
+
+    SECTION("Handles stop state") {
+        mc.handleSensor("state", R"({"state":"start"})");
+        REQUIRE(mc.getMachine()->isRunning());
+
+        mc.handleSensor("state", R"({"state":"stop"})");
+        REQUIRE_FALSE(mc.getMachine()->isRunning());
+    }
+
+    SECTION("Ignores invalid state") {
+        mc.handleSensor("state", R"({"state":"invalid"})");
+        REQUIRE_FALSE(mc.getMachine()->isRunning());
+    }
+
+    SECTION("Handles malformed JSON gracefully") {
+        REQUIRE_NOTHROW(mc.handleSensor("state", R"({bad_json)"));
+    }
+}

--- a/tests/TemperatureSensorTest.cpp
+++ b/tests/TemperatureSensorTest.cpp
@@ -5,9 +5,12 @@
 using Catch::Matchers::WithinAbs;
 
 TEST_CASE("Temperature sensor updates for multiple machines", "[TemperatureSensor]") {
-    FactoryController factory;
-
     SECTION("Each machine stores temperature independently") {
+        FactoryController factory;
+        // Start all machines first
+        factory.handleMessage("factory/machine0/state", R"({"state": "start"})");
+        factory.handleMessage("factory/machine1/state", R"({"state": "start"})");
+        factory.handleMessage("factory/machine2/state", R"({"state": "start"})");
         factory.handleMessage("factory/machine0/temp", R"({"temp": 5.0})");
         factory.handleMessage("factory/machine1/temp", R"({"temp": 22.5})");
         factory.handleMessage("factory/machine2/temp", R"({"temp": 90.0})");

--- a/tests/VibrationSensorTest.cpp
+++ b/tests/VibrationSensorTest.cpp
@@ -7,6 +7,9 @@ using Catch::Matchers::WithinAbs;
 TEST_CASE("Vibration sensor behavior", "[VibrationSensor]") {
     MachineController mc("machine1");
 
+    // Ensure the machine is running before testing sensor behavior
+    mc.handleSensor("state", R"({"state": "start"})");
+
     SECTION("Normal vibration level") {
         mc.handleSensor("vibration", R"({"vibration": 3.2})");
         auto vibration = mc.getMachine()->getSensorValue("vibration");


### PR DESCRIPTION
This pull request introduces a new machine state management feature, allowing machines to be started and stopped, and ensuring sensor data is only processed when machines are running. It also includes updates to tests to validate this functionality. Below are the most important changes grouped by theme:

### Machine State Management

* Added `start`, `stop`, and `isRunning` methods to the `Machine` class, along with a new `running` member variable to track the machine's state (`include/Machine.h`, `src/Machine.cpp`). [[1]](diffhunk://#diff-d74f8e67572106ac9ed570559dd57ab1cf15126791837c201962a7e455ea8cacR13-R16) [[2]](diffhunk://#diff-d74f8e67572106ac9ed570559dd57ab1cf15126791837c201962a7e455ea8cacR33-R34) [[3]](diffhunk://#diff-caeeddccfba7987276057458948e3fdcb7e37c5c626397879676c62500a128a6R5-R20)
* Implemented a new `handleState` method in `MachineController` to process state changes (start/stop) from incoming sensor data (`include/MachineController.h`, `src/MachineController.cpp`). [[1]](diffhunk://#diff-6cb106aa842cab353afd2881867ca73bbb427694fe03c49a85ec2d55221556daR30) [[2]](diffhunk://#diff-e41bc310fce080199a7b0b8f9681ab0810f4667b20078d15d1d8a8a89425a0bbR75-R92)
* Updated `handleTemperature` and `handleVibration` methods in `MachineController` to ignore sensor data if the machine is not running (`src/MachineController.cpp`). [[1]](diffhunk://#diff-e41bc310fce080199a7b0b8f9681ab0810f4667b20078d15d1d8a8a89425a0bbR13-R26) [[2]](diffhunk://#diff-e41bc310fce080199a7b0b8f9681ab0810f4667b20078d15d1d8a8a89425a0bbR52-R56)

### Test Enhancements

* Added a new `MachineStateTest.cpp` file to test machine state transitions and ensure proper handling of valid, invalid, and malformed state data (`tests/MachineStateTest.cpp`).
* Updated existing tests in `FactoryControllerTest.cpp`, `TemperatureSensorTest.cpp`, and `VibrationSensorTest.cpp` to ensure machines are started before processing sensor data (`tests/FactoryControllerTest.cpp`, `tests/TemperatureSensorTest.cpp`, `tests/VibrationSensorTest.cpp`). [[1]](diffhunk://#diff-97ad5f1cae3f9ba01ecd3e6b19d274b113d93ecfe391189cb86fa6c7bc5252e5L11-R21) [[2]](diffhunk://#diff-97ad5f1cae3f9ba01ecd3e6b19d274b113d93ecfe391189cb86fa6c7bc5252e5R53-R65) [[3]](diffhunk://#diff-f059b9ec1f43016df17474daff44f9ac2d6392478d99d7e21d34b3a52a6a9ef7L8-R13) [[4]](diffhunk://#diff-c99a0d51ec8c73ef7c92cf22bd71d03e5a2d2fe996218b8bca3a74c9ad866f66R10-R12)

### Build System Updates

* Added a new test target `machine_state_tests` to the build system for the newly introduced machine state tests (`tests/CMakeLists.txt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to start and stop machines, as well as check if a machine is running.
  - Machines now process sensor data only when running.
  - Machines can receive and handle explicit "state" messages to control their operational status.

- **Bug Fixes**
  - Sensor data is ignored when a machine is not running, preventing unintended updates.

- **Tests**
  - Introduced new tests to verify machine state transitions and ensure sensor data is processed only when machines are running.
  - Updated existing tests to include machine state initialization before processing sensor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->